### PR TITLE
Fix top10 avg calculation

### DIFF
--- a/commands/card-related/cards.ts
+++ b/commands/card-related/cards.ts
@@ -117,7 +117,7 @@ export async function cards(inboundMessage, serverPrefix) {
     }
 
     // get the top 10 average
-    const elo = await updateUserElo(inboundMessage.guild.id, inboundMessage.author.id);
+    const elo = await updateUserElo(inboundMessage.guild.id, discordUserId);
     const eloDisplay = (elo === null ? 'N/A' : elo);
 
     const embeds = [];


### PR DESCRIPTION
When using `;cards @<someuser>` it calculates avg for user that sent message but should for user that was tagged aka `@<someuser>`